### PR TITLE
add count to cli

### DIFF
--- a/build/lib/mypassmaker/__init__.py
+++ b/build/lib/mypassmaker/__init__.py
@@ -100,13 +100,17 @@ if __name__ == "__main__":
     parser.add_argument(
         "--digits", "-d", action="store_true", help="use digits in password"
     )
+    parser.add_argument(
+        "--count", "-c", type=int, help="The number of passwords to be generated.",default=1
+    )
 
     args = parser.parse_args()
-    password = Password.generate(
+    for i in range(args.count):
+        password = Password.generate(
         length=args.length,
         upper_case=args.upper_case,
         lower_case=args.lower_case,
         special_char=args.special_char,
         digits=args.digits,
-    )
-    print(password)
+        )
+        print(password)

--- a/mypassmaker/__init__.py
+++ b/mypassmaker/__init__.py
@@ -100,13 +100,17 @@ if __name__ == "__main__":
     parser.add_argument(
         "--digits", "-d", action="store_true", help="use digits in password"
     )
+    parser.add_argument(
+        "--count", "-c", type=int, help="The number of passwords to be generated.",default=1
+    )
 
     args = parser.parse_args()
-    password = Password.generate(
+    for i in range(args.count):
+        password = Password.generate(
         length=args.length,
         upper_case=args.upper_case,
         lower_case=args.lower_case,
         special_char=args.special_char,
         digits=args.digits,
-    )
-    print(password)
+        )
+        print(password)


### PR DESCRIPTION
add 
--count COUNT, -c COUNT
                        The number of passwords to be generated.

## Summary by Sourcery

Add a count option to the CLI to generate multiple passwords in a single command

New Features:
- Introduce a new CLI option '--count' or '-c' to specify the number of passwords to generate

Enhancements:
- Modify the password generation logic to support generating multiple passwords based on the count parameter